### PR TITLE
Fix runtime exception when parsing json in DataFlex 19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is a set of helper classes for working with web requests and web content in DataFlex.
 
+Supported and tested on DataFlex 14.1-19.1, it most likely also work on earlier versions.
+
 ## JSON Examples
 
 ### Table of Contents

--- a/cJSONParser.pkg
+++ b/cJSONParser.pkg
@@ -535,7 +535,7 @@ Class cJSONParser is a cObject
 
     Procedure _ToCharArray String ByRef s UChar[] ByRef ca
         Address aStr
-        Move (ResizeArray(ca,Length(s))) to ca
+        Move (ResizeArray(ca, Length(s) + 1)) to ca
         Move (AddressOf(ca)) to aStr
         Move s to aStr
     End_Procedure


### PR DESCRIPTION
_ToCharArray sometimes through an unhandled exception because moving a string to a UCHAR[] address actually moves the terminating null of the string, so it moves one more byte than can fit into the allocated UCHAR[]. It looks like it does this in earlier versions of DataFlex also, for example version 14.1, but it does not throw a runtime exception.